### PR TITLE
Fix call to _publish in _ris.on("error", ...)

### DIFF
--- a/bgpalerter.py
+++ b/bgpalerter.py
@@ -33,7 +33,7 @@ class BGPalerter:
         self._ris.on("difference", self._collect_stats_difference)
         self._ris.on("withdrawal", lambda data: self._collect_stats_low_visibility(data, False))
         self._ris.on("announcement", lambda data: self._collect_stats_low_visibility(data, True))
-        self._ris.on("error", lambda data: self._publish(self, "error", data))
+        self._ris.on("error", lambda data: self._publish("error", data))
 
     def _collect_stats_difference(self, data):
         prefix = data["expected"]["prefix"]


### PR DESCRIPTION
Fixes the following exception which is also mentioned in #6 :
```
% python runner.py
Loading prefixes from monitored_prefixes.yml
Subscribing to 136.38.33.0/24
Error while reading the JSON from WS
Traceback (most recent call last):
  File "runner.py", line 56, in <module>
    alerter.monitor(to_be_monitored)
  File "/home/elon/bin/bgpalerter/bgpalerter.py", line 56, in monitor
    self._ris.subscribe(self.monitored_prefixes)
  File "/home/elon/bin/bgpalerter/ris_listener.py", line 193, in subscribe
    call(json_data)
  File "/home/elon/bin/bgpalerter/bgpalerter.py", line 36, in <lambda>
    self._ris.on("error", lambda data: self._publish(self, "error", data))
TypeError: _publish() takes 3 positional arguments but 4 were given
```